### PR TITLE
feat(asyncq): add maxSize option for backpressure

### DIFF
--- a/src/asyncq.spec.ts
+++ b/src/asyncq.spec.ts
@@ -44,3 +44,61 @@ describe("AsyncQueue", () => {
     await expect(iterator.next()).rejects.toBe("reason");
   });
 });
+
+describe("AsyncQueue maxSize", () => {
+  test("enqueue blocks when queue is full and unblocks on dequeue", async () => {
+    const queue = new AsyncQueue<number>({ maxSize: 2 });
+
+    await queue.enqueue(1);
+    await queue.enqueue(2);
+
+    let thirdEnqueued = false;
+    const third = queue.enqueue(3).then(() => {
+      thirdEnqueued = true;
+    });
+
+    // Third enqueue should be blocked — queue is full
+    await Promise.resolve();
+    expect(thirdEnqueued).toBe(false);
+
+    expect(await queue.dequeue()).toBe(1);
+
+    await third;
+    expect(thirdEnqueued).toBe(true);
+  });
+
+  test("multiple blocked enqueuers are processed in order", async () => {
+    const queue = new AsyncQueue<number>({ maxSize: 1 });
+
+    await queue.enqueue(1);
+
+    const order: number[] = [];
+    const p2 = queue.enqueue(2).then(() => order.push(2));
+    const p3 = queue.enqueue(3).then(() => order.push(3));
+
+    await Promise.resolve();
+    expect(order).toEqual([]);
+
+    expect(await queue.dequeue()).toBe(1);
+    await p2;
+    expect(order).toEqual([2]);
+
+    expect(await queue.dequeue()).toBe(2);
+    await p3;
+    expect(order).toEqual([2, 3]);
+  });
+
+  test("abort signal rejects blocked enqueuers", async () => {
+    const controller = new AbortController();
+    const queue = new AsyncQueue<number>({
+      maxSize: 1,
+      signal: controller.signal,
+    });
+
+    await queue.enqueue(1);
+    const blocked = queue.enqueue(2);
+
+    controller.abort("cancelled");
+    await expect(blocked).rejects.toBe("cancelled");
+  });
+});

--- a/src/asyncq.ts
+++ b/src/asyncq.ts
@@ -1,19 +1,30 @@
 import { newPromisePair } from "./internal.js";
+import { validish } from "./simple.js";
 
 type Waiter<T> = {
   resolve: (value: T | Promise<T>) => void;
   reject: (reason?: unknown) => void;
 };
 
+type EnqueueWaiter<T> = {
+  value: T | Promise<T>;
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+};
+
 export class AsyncQueue<T> {
   private promises: Promise<T>[];
   private waiters: Set<Waiter<T>>;
+  private enqueuers: EnqueueWaiter<T>[];
   private _closed = false;
+  private maxSize?: number;
 
-  constructor(options?: { signal?: AbortSignal }) {
+  constructor(options?: { signal?: AbortSignal; maxSize?: number }) {
     this.waiters = new Set();
     this.promises = [];
+    this.enqueuers = [];
     this._closed = false;
+    this.maxSize = options?.maxSize;
 
     if (options?.signal) {
       if (options.signal.aborted) {
@@ -27,6 +38,10 @@ export class AsyncQueue<T> {
               waiter.reject(options.signal?.reason),
             );
             this.waiters.clear();
+            this.enqueuers.forEach((enqueuer) =>
+              enqueuer.reject(options.signal?.reason),
+            );
+            this.enqueuers = [];
           },
           { once: true },
         );
@@ -45,6 +60,14 @@ export class AsyncQueue<T> {
 
   async enqueue(t: Promise<T> | T) {
     if (this._closed) throw new Error("Cannot add to closed queue.");
+
+    if (validish(this.maxSize) && this.promises.length >= this.maxSize) {
+      await new Promise<void>((resolve, reject) => {
+        this.enqueuers.push({ value: t, resolve, reject });
+      });
+      return;
+    }
+
     const waiter: Waiter<T> | undefined = this.waiters.values().next().value;
     if (waiter) {
       this.waiters.delete(waiter);
@@ -56,12 +79,25 @@ export class AsyncQueue<T> {
     }
   }
 
+  private _processNextEnqueuer() {
+    const enqueuer = this.enqueuers.shift();
+    if (!enqueuer) return;
+
+    const pair = newPromisePair<T>();
+    this.promises.push(pair.promise);
+    pair.resolve(enqueuer.value);
+    enqueuer.resolve();
+  }
+
   async dequeue(options?: { signal?: AbortSignal }) {
     const signal = options?.signal;
     if (signal?.aborted) throw new Error(signal.reason);
 
     const promise = this.promises.shift();
-    if (promise) return promise;
+    if (promise) {
+      this._processNextEnqueuer();
+      return promise;
+    }
 
     const { promise: pairPromise, ...waiter } = newPromisePair<T>();
     this.waiters.add(waiter);

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,6 @@
+# TODO
+
+- [ ] Implement Backpressure / MaxSize in `AsyncQueue`
+    - Add a `maxSize` option to the constructor.
+    - Make `enqueue` wait (block) if the queue is full.
+    - Ensure `dequeue` resolves those waiting `enqueue` calls when space becomes available.

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,6 @@
 # TODO
 
 - [ ] Implement Backpressure / MaxSize in `AsyncQueue`
-    - Add a `maxSize` option to the constructor.
-    - Make `enqueue` wait (block) if the queue is full.
-    - Ensure `dequeue` resolves those waiting `enqueue` calls when space becomes available.
+  - Add a `maxSize` option to the constructor.
+  - Make `enqueue` wait (block) if the queue is full.
+  - Ensure `dequeue` resolves those waiting `enqueue` calls when space becomes available.


### PR DESCRIPTION
## Summary

`AsyncQueue` currently has unbounded buffering — a fast producer can enqueue items indefinitely, outpacing a slow consumer and growing memory without limit. This PR adds an optional `maxSize` to cap that buffer.

### Changes

- **`maxSize` constructor option** — when set, the queue will buffer at most `maxSize` items at a time.
- **Backpressure on `enqueue`** — if the queue is full, `await enqueue(value)` suspends until a consumer calls `dequeue` and frees a slot. FIFO order is preserved across multiple blocked producers.
- **Abort signal integration** — if the `AbortSignal` passed to the constructor fires while an `enqueue` is blocked, the pending enqueue rejects with the abort reason.

### Usage

```ts
const queue = new AsyncQueue<number>({ maxSize: 10 });

// producer — will block automatically once 10 items are buffered
async function produce() {
  for (let i = 0; i < 1000; i++) {
    await queue.enqueue(i); // suspends here when the consumer is slow
  }
  queue.close();
}

// consumer — drives the pace
async function consume() {
  for await (const item of queue) {
    await doSomethingSlowWith(item);
  }
}
```

Without `maxSize` the existing unbounded behaviour is unchanged.